### PR TITLE
Add support for YAML configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Create a configuration file in either JSON or YAML format. Here’s an example:
   "hostRoutes": [
     "github.com",
     "private-app.example.com"
-  ],̌
+  ],
   "awsManagedPrefixLists": [
     "pl-02761f4a40454a3c9"
   ]

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ normally support App Connectors.
 
 ## Example
 
-Here is a sample config file, in JSON format:
+Create a configuration file in either JSON or YAML format. Here’s an example:
 
+`config.json`
 ```json
 {
   "routes": [
@@ -44,11 +45,24 @@ Here is a sample config file, in JSON format:
   "hostRoutes": [
     "github.com",
     "private-app.example.com"
-  ],
+  ],̌
   "awsManagedPrefixLists": [
     "pl-02761f4a40454a3c9"
   ]
 }
+```
+or `config.yaml`
+```yaml
+routes:
+  - "172.16.0.0/22"
+  - "192.168.0.0/24"
+hostRoutes:
+  - "special-hostname1.example"
+  - "special-hostname2.example"
+awsManagedPrefixLists:
+  - "pl-02761f4a40454a3c9"
+extraArgs:
+  - "--webclient"
 ```
 
 Run tailscale-manager:

--- a/src/TailscaleManager/Config.hs
+++ b/src/TailscaleManager/Config.hs
@@ -3,15 +3,14 @@
 module TailscaleManager.Config where
 
 import Data.Aeson
+import Data.Aeson (eitherDecodeFileStrict)
 import Data.Aeson.IP ()
 import Data.ByteString.Lazy qualified as LB
 import Data.IP (IPRange)
 import Data.Maybe (fromMaybe)
 import Data.Text
-
--- |Parse our config file.  May throw AesonException on failure.
-loadConfig :: FilePath -> IO TSConfig
-loadConfig fp = LB.readFile fp >>= throwDecode
+import System.FilePath (takeExtension)
+import Data.Yaml (decodeFileEither)
 
 -- |Config file schema
 data TSConfig
@@ -35,3 +34,27 @@ instance FromJSON TSConfig where
                      , tsExtraArgs = fromMaybe [] extraArgs
                      , tsAWSManagedPrefixLists = fromMaybe [] awsManagedPrefixLists
                      })
+
+-- | Load configuration from a file, detecting format based on file extension.
+loadConfig :: FilePath -> IO TSConfig
+loadConfig path = do
+  case takeExtension path of
+    ".json" -> loadConfigFromJSON path
+    ".yaml" -> loadConfigFromYAML path
+    _       -> error "Unsupported file format. Please use .json or .yaml."
+
+-- | Load configuration from a JSON file.
+loadConfigFromJSON :: FilePath -> IO TSConfig
+loadConfigFromJSON path = do
+  result <- eitherDecodeFileStrict path
+  case result of
+    Left err -> error $ "Failed to parse JSON config: " ++ err
+    Right config -> return config
+
+-- | Load configuration from a YAML file.
+loadConfigFromYAML :: FilePath -> IO TSConfig
+loadConfigFromYAML path = do
+  result <- decodeFileEither path
+  case result of
+    Left err -> error $ "Failed to parse YAML config: " ++ show err
+    Right config -> return config

--- a/tailscale-manager.cabal
+++ b/tailscale-manager.cabal
@@ -50,6 +50,8 @@ common deps
       , protolude ^>= 0.3.4
       , raw-strings-qq ^>= 1.1
       , text ^>= 2.0.2
+      , filepath ^>= 1.4.2
+      , yaml ^>= 0.11.8
 
 executable tailscale-manager
     import:           warnings, deps


### PR DESCRIPTION
- Added support for YAML format in tailscale-manager configuration files, allowing flexibility in configuration file formats (JSON or YAML). issue https://github.com/singlestore-labs/tailscale-manager/issues/11