### PR TITLE
flake.nix: Restart forever, with backoff timer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,9 +111,16 @@
               after = ["tailscaled.service"];
               wants = ["tailscaled.service"];
               wantedBy = ["multi-user.target"];
+              # Never give up on trying to restart
+              startLimitIntervalSec = 0;
               serviceConfig = {
                 Type = "exec";
-                Restart = "on-failure";
+                Restart = "always";
+                # Restart at increasing intervals to avoid things like EC2
+                # metadata service rate limits
+                RestartSec = 1;
+                RestartSteps = 30;
+                RestartMaxDelaySec = 60;
                 ExecStart = lib.escapeShellArgs (
                   [ "${cfg.package}/bin/tailscale-manager" configFile
                     "--tailscale=${config.services.tailscale.package}/bin/tailscale"


### PR DESCRIPTION
RestartSteps and RestartMaxDelaySec were introduced in systemd 254:

https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#RestartSteps=