### PR TITLE
Add a VM test to make sure the nixos module actually works

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
 
         checks.tailscale-manager = self.packages.${system}.tailscale-manager;
 
+        checks.vm-test = pkgs.callPackage ./nix/vm-test.nix { inherit self; };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             haskellPackages.haskell-language-server # you must build it with your ghc to work

--- a/nix/vm-test.nix
+++ b/nix/vm-test.nix
@@ -1,0 +1,23 @@
+{ self, lib, pkgs, system, ... }:
+
+let fakeTailscale = pkgs.writeScriptBin "tailscale" ''
+  #!/bin/sh
+  echo "Fake tailscale invoked with args: $*" 1>&2
+'';
+in
+pkgs.nixosTest {
+  name = "tailscale-manager";
+  nodes.machine1 = { config, pkgs, ... }: {
+    imports = [ self.nixosModules.${system}.tailscale-manager ];
+    services.tailscale.package = fakeTailscale;
+    services.tailscale-manager = {
+      enable = true;
+      routes = ["192.168.254.0/24"];
+    };
+    system.stateVersion = "24.11";
+  };
+  testScript = ''
+    machine1.wait_for_unit("tailscale-manager.service")
+    machine1.wait_for_console_text("Fake tailscale invoked with args:.*--advertise-routes=192.168.254.0/24")
+  '';
+}


### PR DESCRIPTION
This is a very simple nixos VM test.  All it does is launch tailscale-manager with a single static route, and watches syslog output to make sure it starts up and calls tailscale (in this case a test fixture taking tailscale's place) to add that route, so we can at least be confident that the systemd unit and the app minimally work.

Take a look at the github Checks tab to see what a run looks like.

A blog post I found helpful: https://blakesmith.me/2024/03/02/running-nixos-tests-with-flakes.html