### PR TITLE
Fix redundant import warnings

### DIFF
--- a/src/TailscaleManager/Config.hs
+++ b/src/TailscaleManager/Config.hs
@@ -3,9 +3,7 @@
 module TailscaleManager.Config where
 
 import Data.Aeson
-import Data.Aeson (eitherDecodeFileStrict)
 import Data.Aeson.IP ()
-import Data.ByteString.Lazy qualified as LB
 import Data.IP (IPRange)
 import Data.Maybe (fromMaybe)
 import Data.Text


### PR DESCRIPTION
These were introduced in eddf6d694dc991e16f02f2b6e126912ad6d4c767

```
src/TailscaleManager/Config.hs:6:1: warning: [-Wunused-imports]
    The import of ‘Data.Aeson’ is redundant
      except perhaps to import instances from ‘Data.Aeson’
    To import instances alone, use: import Data.Aeson()
  |
6 | import Data.Aeson (eitherDecodeFileStrict)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/TailscaleManager/Config.hs:8:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.ByteString.Lazy’ is redundant
      except perhaps to import instances from ‘Data.ByteString.Lazy’
    To import instances alone, use: import Data.ByteString.Lazy()
  |
8 | import Data.ByteString.Lazy qualified as LB
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```